### PR TITLE
Using maximum threads for make in local build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -180,7 +180,7 @@ def build_tvm(llvm_config_path):
     # Run CMake and make
     try:
         subprocess.check_call(["cmake", ".."])
-        subprocess.check_call(["make", "-j"])
+        subprocess.check_call(["make", "-j$(nproc)"])
     except subprocess.CalledProcessError as error:
         raise RuntimeError("Failed to build TVM") from error
     finally:


### PR DESCRIPTION
Change the maximum number of parallel jobs in setup, to avoid out of memory in local build.